### PR TITLE
feat: document API tool, HTTP transport fix, bearer auth, OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## companies-house-cli [1.1.0] / companies-house-mcp [3.1.0] — 2026-05-05
+
+### Added
+- **`download_filing_document` tool** — fetches the actual filed document (PDF / XHTML / XML / JSON) for a filing history item via the Companies House Document API. Handles the two-step redirect flow; supports `file_path` and `base64` return modes (base64 required for remote HTTP servers). Contributed by Jon Bloor ([#18](https://github.com/aicayzer/companies-house-mcp/pull/18)).
+
+### Fixed
+- **HTTP transport crash** — `--http` mode crashed on every request after the first with `Error: Already connected to a transport`. Switched to stateless mode: a fresh `McpServer` + `StreamableHTTPServerTransport` per request, torn down on `res.close`. Contributed by Jon Bloor ([#18](https://github.com/aicayzer/companies-house-mcp/pull/18)).
+
+### Changed
+- **HTTP server: optional bearer-token auth** — set `MCP_BEARER_TOKEN` to require an `Authorization: Bearer` header on `/mcp`. Logs a warning when unset. Contributed by Jon Bloor ([#18](https://github.com/aicayzer/companies-house-mcp/pull/18)).
+- **HTTP server: optional OAuth `client_credentials` grant** — set `MCP_OAUTH_CLIENT_ID` and `MCP_OAUTH_CLIENT_SECRET` to enable `/oauth/token` and `/.well-known/oauth-authorization-server`. Lets Claude desktop's Custom Connector UI authenticate without a manually-pasted bearer token. Contributed by Jon Bloor ([#18](https://github.com/aicayzer/companies-house-mcp/pull/18)).
+- OAuth endpoint logic extracted from `main()` into `src/server/oauth.ts`.
+
+---
+
 ## companies-house-mcp [3.0.1] — 2026-03-27
 
 ### Fixed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "companies-house-cli",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "CLI tool for the UK Companies House API — company search, profiles, officers, filings, ownership, and due diligence",
   "type": "module",
   "exports": {

--- a/packages/cli/src/server/index.ts
+++ b/packages/cli/src/server/index.ts
@@ -40,6 +40,21 @@ function getApiKey(): string {
   return resolved.key;
 }
 
+/** Read a request body to a string. Used for parsing the form-encoded
+ *  body of the OAuth token endpoint. */
+function readRequestBody(req: {
+  on: (event: string, cb: (chunk?: unknown) => void) => void;
+}): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let body = '';
+    req.on('data', (chunk: unknown) => {
+      body += String(chunk);
+    });
+    req.on('end', () => resolve(body));
+    req.on('error', (err: unknown) => reject(err));
+  });
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const isHttp = args.includes('--http');
@@ -87,6 +102,20 @@ async function main(): Promise<void> {
     const port = portArg ? parseInt(portArg, 10) : 3000;
     const expectedToken = process.env.MCP_BEARER_TOKEN?.trim();
 
+    // OAuth (client_credentials grant) — optional, enabled when both
+    // MCP_OAUTH_CLIENT_ID and MCP_OAUTH_CLIENT_SECRET are set. This lets
+    // clients that don't support a manually-pasted bearer header (e.g.
+    // Claude desktop's Custom Connector UI) authenticate via OAuth and
+    // receive an access token that is identical to MCP_BEARER_TOKEN.
+    const oauthClientId = process.env.MCP_OAUTH_CLIENT_ID?.trim();
+    const oauthClientSecret = process.env.MCP_OAUTH_CLIENT_SECRET?.trim();
+    const oauthEnabled = Boolean(oauthClientId && oauthClientSecret);
+    // Optional override for the public URL announced in OAuth discovery
+    // metadata. Falls back to deriving it from the request headers, which
+    // works when the server sits behind Fly's edge (which sets
+    // X-Forwarded-Proto correctly).
+    const publicUrlOverride = process.env.MCP_PUBLIC_URL?.trim();
+
     if (!expectedToken) {
       console.error(
         'WARNING: MCP_BEARER_TOKEN env var not set — server is unauthenticated.\n' +
@@ -94,12 +123,187 @@ async function main(): Promise<void> {
       );
     }
 
+    if (oauthEnabled && !expectedToken) {
+      console.error(
+        'ERROR: MCP_OAUTH_CLIENT_ID/SECRET are set but MCP_BEARER_TOKEN is not.\n' +
+          '       OAuth would have nothing to issue. Aborting.'
+      );
+      process.exit(1);
+    }
+
     const httpServer = http.createServer(async (req, res) => {
       const url = new URL(req.url ?? '/', `http://localhost:${port}`);
 
+      // CORS preflight — Claude desktop may invoke OAuth from a webview.
+      if (req.method === 'OPTIONS') {
+        res.writeHead(204, {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+          'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+          'Access-Control-Max-Age': '86400',
+        });
+        res.end();
+        return;
+      }
+
       if (url.pathname === '/health') {
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ status: 'ok', tools: tools.length }));
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        });
+        res.end(
+          JSON.stringify({
+            status: 'ok',
+            tools: tools.length,
+            oauth: oauthEnabled,
+          }),
+        );
+        return;
+      }
+
+      // ---- OAuth: discovery metadata
+      if (url.pathname === '/.well-known/oauth-authorization-server') {
+        if (!oauthEnabled) {
+          res.writeHead(404);
+          res.end('Not Found');
+          return;
+        }
+        const proto =
+          (req.headers['x-forwarded-proto'] as string | undefined) ??
+          'http';
+        const host =
+          (req.headers.host as string | undefined) ?? `localhost:${port}`;
+        const issuer = publicUrlOverride || `${proto}://${host}`;
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        });
+        res.end(
+          JSON.stringify({
+            issuer,
+            token_endpoint: `${issuer}/oauth/token`,
+            grant_types_supported: ['client_credentials'],
+            token_endpoint_auth_methods_supported: [
+              'client_secret_basic',
+              'client_secret_post',
+            ],
+            response_types_supported: [],
+          }),
+        );
+        return;
+      }
+
+      // ---- OAuth: token endpoint
+      if (url.pathname === '/oauth/token') {
+        if (!oauthEnabled) {
+          res.writeHead(404);
+          res.end('Not Found');
+          return;
+        }
+        if (req.method !== 'POST') {
+          res.writeHead(405, {
+            'Content-Type': 'application/json',
+            Allow: 'POST',
+          });
+          res.end(
+            JSON.stringify({
+              error: 'invalid_request',
+              error_description: 'Only POST is supported',
+            }),
+          );
+          return;
+        }
+
+        let bodyText = '';
+        try {
+          bodyText = await readRequestBody(req);
+        } catch (err) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              error: 'invalid_request',
+              error_description: `Could not read body: ${(err as Error).message}`,
+            }),
+          );
+          return;
+        }
+        const params = new URLSearchParams(bodyText);
+
+        // Client credentials may arrive via HTTP Basic auth header
+        // (RFC 6749 §2.3.1) or in the request body.
+        let clientId: string | undefined;
+        let clientSecret: string | undefined;
+
+        const authHeader =
+          (req.headers.authorization as string | undefined) ?? '';
+        const basicMatch = /^Basic\s+(.+)$/i.exec(authHeader);
+        if (basicMatch && basicMatch[1]) {
+          try {
+            const decoded = Buffer.from(basicMatch[1], 'base64').toString(
+              'utf-8',
+            );
+            const colonIdx = decoded.indexOf(':');
+            if (colonIdx >= 0) {
+              clientId = decodeURIComponent(decoded.slice(0, colonIdx));
+              clientSecret = decodeURIComponent(decoded.slice(colonIdx + 1));
+            }
+          } catch {
+            /* fall through to body credentials */
+          }
+        }
+        if (!clientId) clientId = params.get('client_id') ?? undefined;
+        if (!clientSecret)
+          clientSecret = params.get('client_secret') ?? undefined;
+
+        if (
+          !clientId ||
+          !clientSecret ||
+          clientId !== oauthClientId ||
+          clientSecret !== oauthClientSecret
+        ) {
+          res.writeHead(401, {
+            'Content-Type': 'application/json',
+            'WWW-Authenticate': 'Basic',
+          });
+          res.end(
+            JSON.stringify({
+              error: 'invalid_client',
+              error_description: 'Unknown client_id or client_secret',
+            }),
+          );
+          return;
+        }
+
+        const grantType = params.get('grant_type');
+        if (grantType !== 'client_credentials') {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              error: 'unsupported_grant_type',
+              error_description:
+                'Only client_credentials grant is supported by this server',
+            }),
+          );
+          return;
+        }
+
+        // Issue an access token. We re-use the static MCP_BEARER_TOKEN
+        // value as the access token, which means the existing /mcp
+        // bearer-auth check accepts OAuth-issued tokens with no extra
+        // logic. expires_in is advisory; the server doesn't actually
+        // expire tokens (the static bearer never expires).
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+          Pragma: 'no-cache',
+        });
+        res.end(
+          JSON.stringify({
+            access_token: expectedToken,
+            token_type: 'Bearer',
+            expires_in: 3600,
+          }),
+        );
         return;
       }
 
@@ -179,6 +383,18 @@ async function main(): Promise<void> {
         console.error('Auth: bearer token required (MCP_BEARER_TOKEN)');
       } else {
         console.error('Auth: NONE — set MCP_BEARER_TOKEN before exposing publicly');
+      }
+      if (oauthEnabled) {
+        console.error(
+          'OAuth: enabled — client_credentials grant accepted at /oauth/token',
+        );
+        console.error(
+          `OAuth discovery: http://localhost:${port}/.well-known/oauth-authorization-server`,
+        );
+      } else {
+        console.error(
+          'OAuth: disabled — set MCP_OAUTH_CLIENT_ID and MCP_OAUTH_CLIENT_SECRET to enable',
+        );
       }
     });
   } else {

--- a/packages/cli/src/server/index.ts
+++ b/packages/cli/src/server/index.ts
@@ -18,6 +18,7 @@ import '../tools/filings.js';
 import '../tools/financial.js';
 import '../tools/extended.js';
 import '../tools/composite.js';
+import '../tools/download-filing-document.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const { version } = JSON.parse(

--- a/packages/cli/src/server/index.ts
+++ b/packages/cli/src/server/index.ts
@@ -48,23 +48,36 @@ async function main(): Promise<void> {
 
   const apiKey = getApiKey();
   const client = new APIClient({ api_key: apiKey });
-
-  const server = new McpServer({
-    name: 'companies-house',
-    version,
-  });
-
-  // Register all tools using the new SDK registerTool method
   const tools = getAllTools();
-  for (const tool of tools) {
-    server.registerTool(tool.name, {
-      description: tool.description,
-      inputSchema: tool.inputSchema,
-      annotations: tool.annotations,
-    }, async (params: Record<string, unknown>) => {
-      return tool.execute(client, params);
+
+  /**
+   * Build a fresh McpServer with all tools registered.
+   *
+   * For stdio mode this is called once at startup. For HTTP mode it is
+   * called per request — the MCP SDK doesn't allow re-using a single
+   * server/transport across multiple connections, so each HTTP request
+   * gets a disposable server+transport pair (stateless mode).
+   */
+  const buildServer = (): McpServer => {
+    const s = new McpServer({
+      name: 'companies-house',
+      version,
     });
-  }
+    for (const tool of tools) {
+      s.registerTool(
+        tool.name,
+        {
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+          annotations: tool.annotations,
+        },
+        async (params: Record<string, unknown>) => {
+          return tool.execute(client, params);
+        }
+      );
+    }
+    return s;
+  };
 
   if (isHttp) {
     const { StreamableHTTPServerTransport } = await import(
@@ -72,21 +85,88 @@ async function main(): Promise<void> {
     );
     const http = await import('node:http');
     const port = portArg ? parseInt(portArg, 10) : 3000;
+    const expectedToken = process.env.MCP_BEARER_TOKEN?.trim();
+
+    if (!expectedToken) {
+      console.error(
+        'WARNING: MCP_BEARER_TOKEN env var not set — server is unauthenticated.\n' +
+          '         Do not expose this server publicly without setting a token.'
+      );
+    }
 
     const httpServer = http.createServer(async (req, res) => {
       const url = new URL(req.url ?? '/', `http://localhost:${port}`);
-      if (url.pathname === '/mcp') {
-        const transport = new StreamableHTTPServerTransport({
-          sessionIdGenerator: () => crypto.randomUUID(),
-        });
-        await server.connect(transport);
-        await transport.handleRequest(req, res);
-      } else if (url.pathname === '/health') {
+
+      if (url.pathname === '/health') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ status: 'ok', tools: tools.length }));
-      } else {
+        return;
+      }
+
+      if (url.pathname !== '/mcp') {
         res.writeHead(404);
         res.end('Not Found');
+        return;
+      }
+
+      // Bearer token auth (only enforced when MCP_BEARER_TOKEN is set)
+      if (expectedToken) {
+        const authHeader = req.headers.authorization ?? '';
+        const match = /^Bearer\s+(.+)$/i.exec(authHeader);
+        if (!match || match[1] !== expectedToken) {
+          res.writeHead(401, {
+            'Content-Type': 'application/json',
+            'WWW-Authenticate': 'Bearer',
+          });
+          res.end(JSON.stringify({ error: 'unauthorized' }));
+          return;
+        }
+      }
+
+      // Stateless: build a fresh server + transport per request and tear
+      // them down when the response closes. This works because each MCP
+      // tool call is self-contained — we don't need cross-request session
+      // state for this server.
+      let sessionServer: McpServer | undefined;
+      let transport: InstanceType<typeof StreamableHTTPServerTransport> | undefined;
+      try {
+        transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined, // stateless mode
+        });
+        sessionServer = buildServer();
+
+        const cleanup = () => {
+          try {
+            transport?.close();
+          } catch {
+            /* ignore */
+          }
+          try {
+            sessionServer?.close();
+          } catch {
+            /* ignore */
+          }
+        };
+        res.on('close', cleanup);
+
+        await sessionServer.connect(transport);
+        await transport.handleRequest(req, res);
+      } catch (err) {
+        console.error('Error handling /mcp request:', err);
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'internal_server_error' }));
+        }
+        try {
+          transport?.close();
+        } catch {
+          /* ignore */
+        }
+        try {
+          sessionServer?.close();
+        } catch {
+          /* ignore */
+        }
       }
     });
 
@@ -95,11 +175,19 @@ async function main(): Promise<void> {
       console.error(`MCP endpoint: http://localhost:${port}/mcp`);
       console.error(`Health check: http://localhost:${port}/health`);
       console.error(`${tools.length} tools registered`);
+      if (expectedToken) {
+        console.error('Auth: bearer token required (MCP_BEARER_TOKEN)');
+      } else {
+        console.error('Auth: NONE — set MCP_BEARER_TOKEN before exposing publicly');
+      }
     });
   } else {
+    const server = buildServer();
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.error(`Companies House MCP server (stdio) started — ${tools.length} tools registered`);
+    console.error(
+      `Companies House MCP server (stdio) started — ${tools.length} tools registered`
+    );
   }
 }
 

--- a/packages/cli/src/server/index.ts
+++ b/packages/cli/src/server/index.ts
@@ -8,6 +8,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { APIClient } from '../api/client.js';
 import { getAllTools } from '../tools/registry.js';
 import { resolveApiKey } from '../config.js';
+import { handleOAuthRequest } from './oauth.js';
 
 // Import all tool modules to trigger registration
 import '../tools/search.js';
@@ -38,21 +39,6 @@ function getApiKey(): string {
     process.exit(1);
   }
   return resolved.key;
-}
-
-/** Read a request body to a string. Used for parsing the form-encoded
- *  body of the OAuth token endpoint. */
-function readRequestBody(req: {
-  on: (event: string, cb: (chunk?: unknown) => void) => void;
-}): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    let body = '';
-    req.on('data', (chunk: unknown) => {
-      body += String(chunk);
-    });
-    req.on('end', () => resolve(body));
-    req.on('error', (err: unknown) => reject(err));
-  });
 }
 
 async function main(): Promise<void> {
@@ -102,18 +88,9 @@ async function main(): Promise<void> {
     const port = portArg ? parseInt(portArg, 10) : 3000;
     const expectedToken = process.env.MCP_BEARER_TOKEN?.trim();
 
-    // OAuth (client_credentials grant) — optional, enabled when both
-    // MCP_OAUTH_CLIENT_ID and MCP_OAUTH_CLIENT_SECRET are set. This lets
-    // clients that don't support a manually-pasted bearer header (e.g.
-    // Claude desktop's Custom Connector UI) authenticate via OAuth and
-    // receive an access token that is identical to MCP_BEARER_TOKEN.
     const oauthClientId = process.env.MCP_OAUTH_CLIENT_ID?.trim();
     const oauthClientSecret = process.env.MCP_OAUTH_CLIENT_SECRET?.trim();
     const oauthEnabled = Boolean(oauthClientId && oauthClientSecret);
-    // Optional override for the public URL announced in OAuth discovery
-    // metadata. Falls back to deriving it from the request headers, which
-    // works when the server sits behind Fly's edge (which sets
-    // X-Forwarded-Proto correctly).
     const publicUrlOverride = process.env.MCP_PUBLIC_URL?.trim();
 
     if (!expectedToken) {
@@ -151,159 +128,25 @@ async function main(): Promise<void> {
           'Content-Type': 'application/json',
           'Access-Control-Allow-Origin': '*',
         });
-        res.end(
-          JSON.stringify({
-            status: 'ok',
-            tools: tools.length,
-            oauth: oauthEnabled,
-          }),
-        );
+        res.end(JSON.stringify({ status: 'ok', tools: tools.length, oauth: oauthEnabled }));
         return;
       }
 
-      // ---- OAuth: discovery metadata
-      if (url.pathname === '/.well-known/oauth-authorization-server') {
-        if (!oauthEnabled) {
-          res.writeHead(404);
-          res.end('Not Found');
-          return;
-        }
-        const proto =
-          (req.headers['x-forwarded-proto'] as string | undefined) ??
-          'http';
-        const host =
-          (req.headers.host as string | undefined) ?? `localhost:${port}`;
-        const issuer = publicUrlOverride || `${proto}://${host}`;
-        res.writeHead(200, {
-          'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': '*',
+      if (oauthEnabled) {
+        const handled = await handleOAuthRequest(req, res, url.pathname, {
+          clientId: oauthClientId!,
+          clientSecret: oauthClientSecret!,
+          expectedToken: expectedToken!,
+          publicUrlOverride,
+          port,
         });
-        res.end(
-          JSON.stringify({
-            issuer,
-            token_endpoint: `${issuer}/oauth/token`,
-            grant_types_supported: ['client_credentials'],
-            token_endpoint_auth_methods_supported: [
-              'client_secret_basic',
-              'client_secret_post',
-            ],
-            response_types_supported: [],
-          }),
-        );
-        return;
-      }
-
-      // ---- OAuth: token endpoint
-      if (url.pathname === '/oauth/token') {
-        if (!oauthEnabled) {
-          res.writeHead(404);
-          res.end('Not Found');
-          return;
-        }
-        if (req.method !== 'POST') {
-          res.writeHead(405, {
-            'Content-Type': 'application/json',
-            Allow: 'POST',
-          });
-          res.end(
-            JSON.stringify({
-              error: 'invalid_request',
-              error_description: 'Only POST is supported',
-            }),
-          );
-          return;
-        }
-
-        let bodyText = '';
-        try {
-          bodyText = await readRequestBody(req);
-        } catch (err) {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(
-            JSON.stringify({
-              error: 'invalid_request',
-              error_description: `Could not read body: ${(err as Error).message}`,
-            }),
-          );
-          return;
-        }
-        const params = new URLSearchParams(bodyText);
-
-        // Client credentials may arrive via HTTP Basic auth header
-        // (RFC 6749 §2.3.1) or in the request body.
-        let clientId: string | undefined;
-        let clientSecret: string | undefined;
-
-        const authHeader =
-          (req.headers.authorization as string | undefined) ?? '';
-        const basicMatch = /^Basic\s+(.+)$/i.exec(authHeader);
-        if (basicMatch && basicMatch[1]) {
-          try {
-            const decoded = Buffer.from(basicMatch[1], 'base64').toString(
-              'utf-8',
-            );
-            const colonIdx = decoded.indexOf(':');
-            if (colonIdx >= 0) {
-              clientId = decodeURIComponent(decoded.slice(0, colonIdx));
-              clientSecret = decodeURIComponent(decoded.slice(colonIdx + 1));
-            }
-          } catch {
-            /* fall through to body credentials */
-          }
-        }
-        if (!clientId) clientId = params.get('client_id') ?? undefined;
-        if (!clientSecret)
-          clientSecret = params.get('client_secret') ?? undefined;
-
-        if (
-          !clientId ||
-          !clientSecret ||
-          clientId !== oauthClientId ||
-          clientSecret !== oauthClientSecret
-        ) {
-          res.writeHead(401, {
-            'Content-Type': 'application/json',
-            'WWW-Authenticate': 'Basic',
-          });
-          res.end(
-            JSON.stringify({
-              error: 'invalid_client',
-              error_description: 'Unknown client_id or client_secret',
-            }),
-          );
-          return;
-        }
-
-        const grantType = params.get('grant_type');
-        if (grantType !== 'client_credentials') {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(
-            JSON.stringify({
-              error: 'unsupported_grant_type',
-              error_description:
-                'Only client_credentials grant is supported by this server',
-            }),
-          );
-          return;
-        }
-
-        // Issue an access token. We re-use the static MCP_BEARER_TOKEN
-        // value as the access token, which means the existing /mcp
-        // bearer-auth check accepts OAuth-issued tokens with no extra
-        // logic. expires_in is advisory; the server doesn't actually
-        // expire tokens (the static bearer never expires).
-        res.writeHead(200, {
-          'Content-Type': 'application/json',
-          'Cache-Control': 'no-store',
-          Pragma: 'no-cache',
-        });
-        res.end(
-          JSON.stringify({
-            access_token: expectedToken,
-            token_type: 'Bearer',
-            expires_in: 3600,
-          }),
-        );
+        if (handled) return;
+      } else if (
+        url.pathname === '/.well-known/oauth-authorization-server' ||
+        url.pathname === '/oauth/token'
+      ) {
+        res.writeHead(404);
+        res.end('Not Found');
         return;
       }
 
@@ -316,8 +159,8 @@ async function main(): Promise<void> {
       // Bearer token auth (only enforced when MCP_BEARER_TOKEN is set)
       if (expectedToken) {
         const authHeader = req.headers.authorization ?? '';
-        const match = /^Bearer\s+(.+)$/i.exec(authHeader);
-        if (!match || match[1] !== expectedToken) {
+        const bearerMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+        if (!bearerMatch || bearerMatch[1] !== expectedToken) {
           res.writeHead(401, {
             'Content-Type': 'application/json',
             'WWW-Authenticate': 'Bearer',
@@ -340,16 +183,8 @@ async function main(): Promise<void> {
         sessionServer = buildServer();
 
         const cleanup = () => {
-          try {
-            transport?.close();
-          } catch {
-            /* ignore */
-          }
-          try {
-            sessionServer?.close();
-          } catch {
-            /* ignore */
-          }
+          try { transport?.close(); } catch { /* ignore */ }
+          try { sessionServer?.close(); } catch { /* ignore */ }
         };
         res.on('close', cleanup);
 
@@ -361,16 +196,8 @@ async function main(): Promise<void> {
           res.writeHead(500, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'internal_server_error' }));
         }
-        try {
-          transport?.close();
-        } catch {
-          /* ignore */
-        }
-        try {
-          sessionServer?.close();
-        } catch {
-          /* ignore */
-        }
+        try { transport?.close(); } catch { /* ignore */ }
+        try { sessionServer?.close(); } catch { /* ignore */ }
       }
     });
 
@@ -385,16 +212,10 @@ async function main(): Promise<void> {
         console.error('Auth: NONE — set MCP_BEARER_TOKEN before exposing publicly');
       }
       if (oauthEnabled) {
-        console.error(
-          'OAuth: enabled — client_credentials grant accepted at /oauth/token',
-        );
-        console.error(
-          `OAuth discovery: http://localhost:${port}/.well-known/oauth-authorization-server`,
-        );
+        console.error('OAuth: enabled — client_credentials grant accepted at /oauth/token');
+        console.error(`OAuth discovery: http://localhost:${port}/.well-known/oauth-authorization-server`);
       } else {
-        console.error(
-          'OAuth: disabled — set MCP_OAUTH_CLIENT_ID and MCP_OAUTH_CLIENT_SECRET to enable',
-        );
+        console.error('OAuth: disabled — set MCP_OAUTH_CLIENT_ID and MCP_OAUTH_CLIENT_SECRET to enable');
       }
     });
   } else {

--- a/packages/cli/src/server/oauth.ts
+++ b/packages/cli/src/server/oauth.ts
@@ -1,0 +1,157 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+export interface OAuthConfig {
+  clientId: string;
+  clientSecret: string;
+  expectedToken: string;
+  publicUrlOverride: string | undefined;
+  port: number;
+}
+
+function readRequestBody(req: IncomingMessage): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let body = '';
+    req.on('data', (chunk: unknown) => {
+      body += String(chunk);
+    });
+    req.on('end', () => resolve(body));
+    req.on('error', (err: unknown) => reject(err));
+  });
+}
+
+/**
+ * Handle OAuth discovery and token endpoints.
+ * Returns true if the request was handled (caller should return), false otherwise.
+ */
+export async function handleOAuthRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  pathname: string,
+  config: OAuthConfig,
+): Promise<boolean> {
+  if (pathname === '/.well-known/oauth-authorization-server') {
+    const proto =
+      (req.headers['x-forwarded-proto'] as string | undefined) ?? 'http';
+    const host =
+      (req.headers.host as string | undefined) ?? `localhost:${config.port}`;
+    const issuer = config.publicUrlOverride || `${proto}://${host}`;
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+    });
+    res.end(
+      JSON.stringify({
+        issuer,
+        token_endpoint: `${issuer}/oauth/token`,
+        grant_types_supported: ['client_credentials'],
+        token_endpoint_auth_methods_supported: [
+          'client_secret_basic',
+          'client_secret_post',
+        ],
+        response_types_supported: [],
+      }),
+    );
+    return true;
+  }
+
+  if (pathname === '/oauth/token') {
+    if (req.method !== 'POST') {
+      res.writeHead(405, { 'Content-Type': 'application/json', Allow: 'POST' });
+      res.end(
+        JSON.stringify({
+          error: 'invalid_request',
+          error_description: 'Only POST is supported',
+        }),
+      );
+      return true;
+    }
+
+    let bodyText = '';
+    try {
+      bodyText = await readRequestBody(req);
+    } catch (err) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          error: 'invalid_request',
+          error_description: `Could not read body: ${(err as Error).message}`,
+        }),
+      );
+      return true;
+    }
+
+    const params = new URLSearchParams(bodyText);
+
+    // Client credentials may arrive via HTTP Basic auth (RFC 6749 §2.3.1) or body.
+    let clientId: string | undefined;
+    let clientSecret: string | undefined;
+
+    const authHeader = (req.headers.authorization as string | undefined) ?? '';
+    const basicMatch = authHeader.match(/^Basic\s+(.+)$/i);
+    if (basicMatch && basicMatch[1]) {
+      try {
+        const decoded = Buffer.from(basicMatch[1], 'base64').toString('utf-8');
+        const colonIdx = decoded.indexOf(':');
+        if (colonIdx >= 0) {
+          clientId = decodeURIComponent(decoded.slice(0, colonIdx));
+          clientSecret = decodeURIComponent(decoded.slice(colonIdx + 1));
+        }
+      } catch {
+        /* fall through to body credentials */
+      }
+    }
+    if (!clientId) clientId = params.get('client_id') ?? undefined;
+    if (!clientSecret) clientSecret = params.get('client_secret') ?? undefined;
+
+    if (
+      !clientId ||
+      !clientSecret ||
+      clientId !== config.clientId ||
+      clientSecret !== config.clientSecret
+    ) {
+      res.writeHead(401, {
+        'Content-Type': 'application/json',
+        'WWW-Authenticate': 'Basic',
+      });
+      res.end(
+        JSON.stringify({
+          error: 'invalid_client',
+          error_description: 'Unknown client_id or client_secret',
+        }),
+      );
+      return true;
+    }
+
+    const grantType = params.get('grant_type');
+    if (grantType !== 'client_credentials') {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          error: 'unsupported_grant_type',
+          error_description:
+            'Only client_credentials grant is supported by this server',
+        }),
+      );
+      return true;
+    }
+
+    // Re-use the static MCP_BEARER_TOKEN as the access token — the /mcp
+    // bearer-auth check accepts it with no extra logic. expires_in is
+    // advisory; the token never actually expires.
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+      Pragma: 'no-cache',
+    });
+    res.end(
+      JSON.stringify({
+        access_token: config.expectedToken,
+        token_type: 'Bearer',
+        expires_in: 3600,
+      }),
+    );
+    return true;
+  }
+
+  return false;
+}

--- a/packages/cli/src/tools/download-filing-document.ts
+++ b/packages/cli/src/tools/download-filing-document.ts
@@ -1,0 +1,330 @@
+/**
+ * Companies House Document API tool — download the actual filed document
+ * (PDF / XHTML / XML / JSON) for a given filing history item.
+ *
+ * The standard REST API (api.company-information.service.gov.uk) only returns
+ * filing metadata. The underlying documents live on a separate service at
+ * document-api.company-information.service.gov.uk and follow a two-step
+ * request flow:
+ *
+ *   1. GET  /document/{document_id}             -> metadata + resources map
+ *   2. GET  /document/{document_id}/content     -> 302 redirect to a signed
+ *                                                  S3 URL containing the file
+ *
+ * This tool performs both steps, writes the resulting bytes to a file, and
+ * returns the local file path (plus content-type/size) so downstream tooling
+ * can read, parse or email the document.
+ *
+ * Save location precedence (highest first):
+ *   1. `save_dir` parameter on the call
+ *   2. `COMPANIES_HOUSE_DOWNLOAD_DIR` environment variable
+ *   3. OS temp directory (the historical default)
+ *
+ * Drop this file into packages/cli/src/tools/ and add a matching
+ * `import '../tools/download-filing-document.js';` line to
+ * packages/cli/src/server/index.ts — see PATCH.md for the one-line change.
+ */
+
+import { z } from 'zod';
+import { writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import {
+  registerTool,
+  TOOL_ANNOTATIONS,
+  makeTextResult,
+  makeErrorResult,
+} from './registry.js';
+import { resolveApiKey } from '../config.js';
+import type { APIClient } from '../api/client.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DOCUMENT_API_BASE_URL =
+  'https://document-api.company-information.service.gov.uk';
+
+const DOWNLOAD_DIR_ENV_VAR = 'COMPANIES_HOUSE_DOWNLOAD_DIR';
+
+type Format = 'pdf' | 'xhtml' | 'xml' | 'json';
+
+/** Map of user-facing format strings to the Accept header value the
+ *  Document API expects. Companies House serves most filings as PDF and a
+ *  subset (mostly modern accounts) as iXBRL/XHTML or XML. */
+const FORMAT_ACCEPT: Record<Format, string> = {
+  pdf: 'application/pdf',
+  xhtml: 'application/xhtml+xml',
+  xml: 'application/xml',
+  json: 'application/json',
+};
+
+const FORMAT_EXTENSION: Record<Format, string> = {
+  pdf: 'pdf',
+  xhtml: 'xhtml',
+  xml: 'xml',
+  json: 'json',
+};
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const shape = {
+  document_id: z
+    .string()
+    .min(1)
+    .describe(
+      'The document id from a filing history item. Typically exposed on a ' +
+        'filing as `links.document_metadata` (e.g. ".../document/ABC123"); ' +
+        'pass just the final path segment here.',
+    ),
+  format: z
+    .enum(['pdf', 'xhtml', 'xml', 'json'])
+    .default('pdf')
+    .describe(
+      'Preferred content type. Defaults to pdf. The Document API will ' +
+        'return the requested format if available and otherwise fall back ' +
+        'to whatever it holds.',
+    ),
+  company_number: z
+    .string()
+    .optional()
+    .describe(
+      'Optional — used only for the returned filename so you can tell ' +
+        'multiple downloads apart.',
+    ),
+  transaction_id: z
+    .string()
+    .optional()
+    .describe(
+      'Optional transaction id from the filing history item. Included in ' +
+        'the returned filename and response payload when supplied.',
+    ),
+  save_dir: z
+    .string()
+    .optional()
+    .describe(
+      'Optional absolute path to save the downloaded file into. Overrides ' +
+        'the `COMPANIES_HOUSE_DOWNLOAD_DIR` env var and the OS temp ' +
+        'directory default. The directory will be created if it does not ' +
+        'already exist.',
+    ),
+};
+const schema = z.object(shape);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Strip any leading path so callers can pass either a raw id or the full
+ *  `links.document_metadata` URL the REST API hands back. */
+function normaliseDocumentId(raw: string): string {
+  const trimmed = raw.trim().replace(/\/+$/, '');
+  const marker = '/document/';
+  const idx = trimmed.lastIndexOf(marker);
+  if (idx >= 0) return trimmed.slice(idx + marker.length);
+  return trimmed.split('/').pop() ?? trimmed;
+}
+
+/** Resolve the directory to save into, applying precedence:
+ *  explicit param > env var > OS temp dir. */
+function resolveSaveDir(paramValue: string | undefined): {
+  dir: string;
+  source: 'param' | 'env' | 'tmpdir';
+} {
+  if (paramValue && paramValue.trim()) {
+    return { dir: paramValue.trim(), source: 'param' };
+  }
+  const envValue = process.env[DOWNLOAD_DIR_ENV_VAR];
+  if (envValue && envValue.trim()) {
+    return { dir: envValue.trim(), source: 'env' };
+  }
+  return { dir: tmpdir(), source: 'tmpdir' };
+}
+
+/** Build the HTTP Basic auth header the Document API expects (same scheme
+ *  as the REST API — API key as username, empty password). */
+function buildAuthHeader(apiKey: string): string {
+  return 'Basic ' + Buffer.from(apiKey + ':').toString('base64');
+}
+
+interface FetchedDocument {
+  buffer: Buffer;
+  contentType: string;
+  metadata: Record<string, unknown> | null;
+}
+
+async function fetchDocument(
+  documentId: string,
+  format: Format,
+  apiKey: string,
+): Promise<FetchedDocument> {
+  const auth = buildAuthHeader(apiKey);
+  const accept = FORMAT_ACCEPT[format];
+
+  // ---- Step 1: metadata (optional but cheap and helpful for diagnostics).
+  let metadata: Record<string, unknown> | null = null;
+  try {
+    const metaRes = await fetch(
+      `${DOCUMENT_API_BASE_URL}/document/${encodeURIComponent(documentId)}`,
+      {
+        headers: {
+          Authorization: auth,
+          Accept: 'application/json',
+        },
+      },
+    );
+    if (metaRes.ok) {
+      metadata = (await metaRes.json()) as Record<string, unknown>;
+    }
+    // If metadata fetch fails we don't abort — content may still succeed.
+  } catch {
+    /* swallow — metadata is best-effort */
+  }
+
+  // ---- Step 2: content. The Document API responds with a 302 redirect to a
+  //      signed S3 URL. We request redirect:'manual' so the auth header is
+  //      NOT forwarded to S3 (which would reject it), then follow manually.
+  const contentUrl =
+    `${DOCUMENT_API_BASE_URL}/document/` +
+    `${encodeURIComponent(documentId)}/content`;
+
+  const firstRes = await fetch(contentUrl, {
+    method: 'GET',
+    redirect: 'manual',
+    headers: {
+      Authorization: auth,
+      Accept: accept,
+    },
+  });
+
+  let finalRes: Response;
+  if (firstRes.status >= 300 && firstRes.status < 400) {
+    const location = firstRes.headers.get('location');
+    if (!location) {
+      throw new Error(
+        `Document API returned ${firstRes.status} with no Location header`,
+      );
+    }
+    // Signed S3 URL — no auth header this time.
+    finalRes = await fetch(location, { method: 'GET' });
+  } else {
+    finalRes = firstRes;
+  }
+
+  if (!finalRes.ok) {
+    const body = await safeReadText(finalRes);
+    throw new Error(
+      `Document content fetch failed: ${finalRes.status} ${finalRes.statusText}` +
+        (body ? ` — ${body.slice(0, 500)}` : ''),
+    );
+  }
+
+  const arrayBuf = await finalRes.arrayBuffer();
+  const buffer = Buffer.from(arrayBuf);
+  const contentType =
+    finalRes.headers.get('content-type') ?? accept ?? 'application/octet-stream';
+
+  return { buffer, contentType, metadata };
+}
+
+async function safeReadText(res: Response): Promise<string> {
+  try {
+    return await res.text();
+  } catch {
+    return '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool registration
+// ---------------------------------------------------------------------------
+
+registerTool({
+  name: 'download_filing_document',
+  description:
+    'Download the actual filed document (PDF / XHTML / XML / JSON) for a ' +
+    'Companies House filing history item via the Document API and save it ' +
+    'to disk. Returns the file path, detected content-type and size in ' +
+    'bytes. Pair this with `get_filings` — take the `links.' +
+    'document_metadata` value from a filing and pass its final path segment ' +
+    'as `document_id`. Save location: explicit `save_dir` param > ' +
+    '`COMPANIES_HOUSE_DOWNLOAD_DIR` env var > OS temp directory.',
+  inputSchema: shape,
+  annotations: TOOL_ANNOTATIONS,
+  async execute(_client: APIClient, params: unknown) {
+    const input = schema.parse(params);
+    const documentId = normaliseDocumentId(input.document_id);
+
+    const resolved = resolveApiKey();
+    if (!resolved) {
+      return makeErrorResult(
+        'Companies House API key not configured. Set the COMPANIES_HOUSE_API_KEY environment variable or run `ch config` to store one.',
+      );
+    }
+    const apiKey = resolved.key;
+
+    try {
+      const { buffer, contentType, metadata } = await fetchDocument(
+        documentId,
+        input.format,
+        apiKey,
+      );
+
+      const ext = FORMAT_EXTENSION[input.format] ?? 'bin';
+      const companyPart = input.company_number ? `${input.company_number}_` : '';
+      const txnPart = input.transaction_id ? `${input.transaction_id}_` : '';
+      const filename = `${companyPart}${txnPart}${documentId}_${randomUUID().slice(
+        0,
+        8,
+      )}.${ext}`;
+
+      const { dir: saveDir, source: saveDirSource } = resolveSaveDir(
+        input.save_dir,
+      );
+
+      // Make sure the target directory exists. `recursive: true` is a no-op
+      // if it's already there and creates intermediate paths if it isn't.
+      try {
+        await mkdir(saveDir, { recursive: true });
+      } catch (err) {
+        return makeErrorResult(
+          `Could not create save directory '${saveDir}': ${(err as Error).message}`,
+        );
+      }
+
+      const filePath = join(saveDir, filename);
+
+      await writeFile(filePath, buffer);
+
+      const payload: Record<string, unknown> = {
+        file_path: filePath,
+        filename,
+        save_dir: saveDir,
+        save_dir_source: saveDirSource,
+        content_type: contentType,
+        size_bytes: buffer.byteLength,
+        document_id: documentId,
+        requested_format: input.format,
+        ...(input.company_number
+          ? { company_number: input.company_number }
+          : {}),
+        ...(input.transaction_id
+          ? { transaction_id: input.transaction_id }
+          : {}),
+        ...(metadata ? { metadata } : {}),
+      };
+
+      const summary =
+        `Saved ${buffer.byteLength.toLocaleString()} bytes (${contentType}) to ${filePath} ` +
+        `[save_dir source: ${saveDirSource}]`;
+
+      return makeTextResult(summary, payload);
+    } catch (err) {
+      return makeErrorResult((err as Error).message);
+    }
+  },
+});

--- a/packages/cli/src/tools/download-filing-document.ts
+++ b/packages/cli/src/tools/download-filing-document.ts
@@ -11,18 +11,18 @@
  *   2. GET  /document/{document_id}/content     -> 302 redirect to a signed
  *                                                  S3 URL containing the file
  *
- * This tool performs both steps, writes the resulting bytes to a file, and
- * returns the local file path (plus content-type/size) so downstream tooling
- * can read, parse or email the document.
+ * This tool performs both steps and then EITHER:
+ *   - writes the bytes to a file on the server's disk and returns the local
+ *     path (default — `return_as: 'file_path'`); or
+ *   - returns the bytes inline as a base64 string in the response payload
+ *     (`return_as: 'base64'`), which is what you want when the MCP server
+ *     runs on a different machine to the caller (e.g. hosted on Fly.io and
+ *     accessed over HTTP via mcp-remote).
  *
- * Save location precedence (highest first):
+ * Save location precedence (file_path mode only):
  *   1. `save_dir` parameter on the call
  *   2. `COMPANIES_HOUSE_DOWNLOAD_DIR` environment variable
  *   3. OS temp directory (the historical default)
- *
- * Drop this file into packages/cli/src/tools/ and add a matching
- * `import '../tools/download-filing-document.js';` line to
- * packages/cli/src/server/index.ts — see PATCH.md for the one-line change.
  */
 
 import { z } from 'zod';
@@ -89,6 +89,17 @@ const shape = {
         'return the requested format if available and otherwise fall back ' +
         'to whatever it holds.',
     ),
+  return_as: z
+    .enum(['file_path', 'base64'])
+    .default('file_path')
+    .describe(
+      'How to return the document. "file_path" (default) writes the bytes ' +
+        'to disk on the server and returns the local path — works when ' +
+        'the MCP server runs on the same machine as the caller (stdio ' +
+        'mode). "base64" returns the bytes inline as a base64 string in ' +
+        'the response payload — required when the server is remote (HTTP) ' +
+        'and the caller has no access to the server filesystem.',
+    ),
   company_number: z
     .string()
     .optional()
@@ -107,10 +118,11 @@ const shape = {
     .string()
     .optional()
     .describe(
-      'Optional absolute path to save the downloaded file into. Overrides ' +
-        'the `COMPANIES_HOUSE_DOWNLOAD_DIR` env var and the OS temp ' +
-        'directory default. The directory will be created if it does not ' +
-        'already exist.',
+      'Optional absolute path to save the downloaded file into (file_path ' +
+        'mode only). Overrides the `COMPANIES_HOUSE_DOWNLOAD_DIR` env var ' +
+        'and the OS temp directory default. The directory will be created ' +
+        'if it does not already exist. Ignored when `return_as` is ' +
+        '"base64".',
     ),
 };
 const schema = z.object(shape);
@@ -247,12 +259,12 @@ registerTool({
   name: 'download_filing_document',
   description:
     'Download the actual filed document (PDF / XHTML / XML / JSON) for a ' +
-    'Companies House filing history item via the Document API and save it ' +
-    'to disk. Returns the file path, detected content-type and size in ' +
-    'bytes. Pair this with `get_filings` — take the `links.' +
-    'document_metadata` value from a filing and pass its final path segment ' +
-    'as `document_id`. Save location: explicit `save_dir` param > ' +
-    '`COMPANIES_HOUSE_DOWNLOAD_DIR` env var > OS temp directory.',
+    'Companies House filing history item via the Document API. By default ' +
+    'writes to disk on the server and returns the file path; pass ' +
+    '`return_as: "base64"` to get the bytes inline (required for remote ' +
+    'MCP servers). Pair with `get_filings` — take the `links.' +
+    'document_metadata` value from a filing and pass its final path ' +
+    'segment as `document_id`.',
   inputSchema: shape,
   annotations: TOOL_ANNOTATIONS,
   async execute(_client: APIClient, params: unknown) {
@@ -274,6 +286,37 @@ registerTool({
         apiKey,
       );
 
+      const commonPayload: Record<string, unknown> = {
+        content_type: contentType,
+        size_bytes: buffer.byteLength,
+        document_id: documentId,
+        requested_format: input.format,
+        ...(input.company_number
+          ? { company_number: input.company_number }
+          : {}),
+        ...(input.transaction_id
+          ? { transaction_id: input.transaction_id }
+          : {}),
+        ...(metadata ? { metadata } : {}),
+      };
+
+      // ---- base64 mode: return the bytes inline, no disk write.
+      if (input.return_as === 'base64') {
+        const payload = {
+          ...commonPayload,
+          return_as: 'base64',
+          content_base64: buffer.toString('base64'),
+        };
+        const summary =
+          `Returning ${buffer.byteLength.toLocaleString()} bytes ` +
+          `(${contentType}) inline as base64. Decode with e.g. ` +
+          `\`echo "$content_base64" | base64 -d > out.${
+            FORMAT_EXTENSION[input.format] ?? 'bin'
+          }\`.`;
+        return makeTextResult(summary, payload);
+      }
+
+      // ---- file_path mode (default): write to disk, return the path.
       const ext = FORMAT_EXTENSION[input.format] ?? 'bin';
       const companyPart = input.company_number ? `${input.company_number}_` : '';
       const txnPart = input.transaction_id ? `${input.transaction_id}_` : '';
@@ -286,8 +329,6 @@ registerTool({
         input.save_dir,
       );
 
-      // Make sure the target directory exists. `recursive: true` is a no-op
-      // if it's already there and creates intermediate paths if it isn't.
       try {
         await mkdir(saveDir, { recursive: true });
       } catch (err) {
@@ -297,25 +338,15 @@ registerTool({
       }
 
       const filePath = join(saveDir, filename);
-
       await writeFile(filePath, buffer);
 
-      const payload: Record<string, unknown> = {
+      const payload = {
+        ...commonPayload,
+        return_as: 'file_path',
         file_path: filePath,
         filename,
         save_dir: saveDir,
         save_dir_source: saveDirSource,
-        content_type: contentType,
-        size_bytes: buffer.byteLength,
-        document_id: documentId,
-        requested_format: input.format,
-        ...(input.company_number
-          ? { company_number: input.company_number }
-          : {}),
-        ...(input.transaction_id
-          ? { transaction_id: input.transaction_id }
-          : {}),
-        ...(metadata ? { metadata } : {}),
       };
 
       const summary =

--- a/packages/cli/tests/unit/tools/download-filing-document.test.ts
+++ b/packages/cli/tests/unit/tools/download-filing-document.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { APIClient } from '../../../src/api/client.js';
+import { getTool } from '../../../src/tools/registry.js';
+
+vi.mock('../../../src/config.js', () => ({
+  resolveApiKey: vi.fn(() => ({ key: 'test-api-key', source: 'env' })),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn(() => Promise.resolve()),
+  mkdir: vi.fn(() => Promise.resolve()),
+}));
+
+import '../../../src/tools/download-filing-document.js';
+import { resolveApiKey } from '../../../src/config.js';
+import { writeFile, mkdir } from 'node:fs/promises';
+
+// Minimal client — download_filing_document doesn't use APIClient at all,
+// but execute() takes one as its first argument.
+const client = new APIClient({ api_key: 'test', cache_enabled: false });
+
+const FAKE_PDF = Buffer.from('%PDF-1.4 fake content');
+const S3_URL = 'https://s3.amazonaws.com/companies-house-documents/fake-signed-url';
+const MOCK_METADATA = { company_number: '12345678', description: 'Annual accounts' };
+
+function makeFetchMock({
+  metaOk = true,
+  contentStatus = 302,
+  s3Status = 200,
+  s3Body = FAKE_PDF,
+}: {
+  metaOk?: boolean;
+  contentStatus?: number;
+  s3Status?: number;
+  s3Body?: Buffer;
+} = {}) {
+  return vi.fn(async (url: string) => {
+    const u = typeof url === 'string' ? url : String(url);
+
+    // Metadata endpoint
+    if (u.includes('/document/') && !u.includes('/content')) {
+      if (!metaOk) return new Response('{}', { status: 500 });
+      return new Response(JSON.stringify(MOCK_METADATA), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Content endpoint (returns redirect or direct response)
+    if (u.includes('/content')) {
+      if (contentStatus >= 300 && contentStatus < 400) {
+        return new Response(null, {
+          status: contentStatus,
+          headers: { Location: S3_URL },
+        });
+      }
+      // Direct 200 (no redirect)
+      return new Response(new Uint8Array(s3Body), {
+        status: contentStatus,
+        headers: { 'Content-Type': 'application/pdf' },
+      });
+    }
+
+    // S3 URL — should have no auth header
+    if (u === S3_URL) {
+      if (s3Status !== 200) {
+        return new Response('Error', { status: s3Status });
+      }
+      return new Response(new Uint8Array(s3Body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/pdf' },
+      });
+    }
+
+    throw new Error(`Unexpected fetch URL: ${u}`);
+  }) as typeof globalThis.fetch;
+}
+
+describe('download_filing_document', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalEnv = process.env.COMPANIES_HOUSE_DOWNLOAD_DIR;
+    delete process.env.COMPANIES_HOUSE_DOWNLOAD_DIR;
+    vi.mocked(resolveApiKey).mockReturnValue({ key: 'test-api-key', source: 'env' });
+    vi.mocked(writeFile).mockResolvedValue(undefined);
+    vi.mocked(mkdir).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalEnv !== undefined) {
+      process.env.COMPANIES_HOUSE_DOWNLOAD_DIR = originalEnv;
+    } else {
+      delete process.env.COMPANIES_HOUSE_DOWNLOAD_DIR;
+    }
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // normaliseDocumentId — tested indirectly via the URL fetch is called with
+  // -------------------------------------------------------------------------
+
+  it('accepts a bare document ID', async () => {
+    globalThis.fetch = makeFetchMock();
+    const tool = getTool('download_filing_document')!;
+    await tool.execute(client, { document_id: 'ABC123', return_as: 'base64' });
+    const calls = vi.mocked(globalThis.fetch).mock.calls.map(([u]) => u as string);
+    expect(calls.some(u => u.includes('/document/ABC123'))).toBe(true);
+  });
+
+  it('strips /document/ path prefix from ID', async () => {
+    globalThis.fetch = makeFetchMock();
+    const tool = getTool('download_filing_document')!;
+    await tool.execute(client, { document_id: '/document/ABC123', return_as: 'base64' });
+    const calls = vi.mocked(globalThis.fetch).mock.calls.map(([u]) => u as string);
+    // Should NOT double-encode /document/document/
+    expect(calls.some(u => u.endsWith('/document/ABC123') || u.endsWith('/document/ABC123/content'))).toBe(true);
+    expect(calls.every(u => !u.includes('/document/document/'))).toBe(true);
+  });
+
+  it('strips full Document API URL to bare ID', async () => {
+    globalThis.fetch = makeFetchMock();
+    const tool = getTool('download_filing_document')!;
+    const fullUrl = 'https://document-api.company-information.service.gov.uk/document/ABC123';
+    await tool.execute(client, { document_id: fullUrl, return_as: 'base64' });
+    const calls = vi.mocked(globalThis.fetch).mock.calls.map(([u]) => u as string);
+    expect(calls.every(u => !u.includes('/document/document/'))).toBe(true);
+    expect(calls.some(u => u.includes('/document/ABC123'))).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful download — file_path mode
+  // -------------------------------------------------------------------------
+
+  it('writes bytes to disk and returns file_path', async () => {
+    globalThis.fetch = makeFetchMock();
+    const tool = getTool('download_filing_document')!;
+    const result = await tool.execute(client, {
+      document_id: 'DOC001',
+      format: 'pdf',
+      return_as: 'file_path',
+      save_dir: '/tmp/test-downloads',
+    });
+    expect(result.isError).toBeFalsy();
+    expect(vi.mocked(mkdir)).toHaveBeenCalledWith('/tmp/test-downloads', { recursive: true });
+    expect(vi.mocked(writeFile)).toHaveBeenCalledOnce();
+    const [filePath, buf] = vi.mocked(writeFile).mock.calls[0] as [string, Buffer];
+    expect(filePath).toMatch(/^\/tmp\/test-downloads\/.+\.pdf$/);
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect((result.structuredContent as Record<string, unknown>)?.return_as).toBe('file_path');
+    expect((result.structuredContent as Record<string, unknown>)?.file_path).toBe(filePath);
+  });
+
+  // -------------------------------------------------------------------------
+  // S3 redirect: auth header must NOT be forwarded
+  // -------------------------------------------------------------------------
+
+  it('does not send Authorization header to S3', async () => {
+    globalThis.fetch = makeFetchMock();
+    const tool = getTool('download_filing_document')!;
+    await tool.execute(client, { document_id: 'DOC002', return_as: 'base64' });
+
+    const fetchCalls = vi.mocked(globalThis.fetch).mock.calls as Array<[string, RequestInit?]>;
+    const s3Call = fetchCalls.find(([u]) => u === S3_URL);
+    expect(s3Call).toBeDefined();
+    const s3Init = s3Call![1];
+    const headers = s3Init?.headers as Record<string, string> | undefined;
+    expect(headers?.['Authorization']).toBeUndefined();
+    expect(headers?.['authorization']).toBeUndefined();
+  });
+
+  it('sends Authorization header to Document API', async () => {
+    globalThis.fetch = makeFetchMock();
+    const tool = getTool('download_filing_document')!;
+    await tool.execute(client, { document_id: 'DOC002', return_as: 'base64' });
+
+    const fetchCalls = vi.mocked(globalThis.fetch).mock.calls as Array<[string, RequestInit?]>;
+    const contentCall = fetchCalls.find(([u]) => (u as string).includes('/content'));
+    expect(contentCall).toBeDefined();
+    const headers = contentCall![1]?.headers as Record<string, string> | undefined;
+    expect(headers?.['Authorization']).toMatch(/^Basic /);
+  });
+
+  // -------------------------------------------------------------------------
+  // base64 return mode
+  // -------------------------------------------------------------------------
+
+  it('returns bytes inline as base64, no disk write', async () => {
+    globalThis.fetch = makeFetchMock();
+    const tool = getTool('download_filing_document')!;
+    const result = await tool.execute(client, {
+      document_id: 'DOC003',
+      return_as: 'base64',
+    });
+    expect(result.isError).toBeFalsy();
+    expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
+    const sc = result.structuredContent as Record<string, unknown>;
+    expect(sc?.return_as).toBe('base64');
+    expect(typeof sc?.content_base64).toBe('string');
+    // Decoded bytes should match what the mock returned
+    const decoded = Buffer.from(sc!.content_base64 as string, 'base64');
+    expect(decoded).toEqual(FAKE_PDF);
+  });
+
+  // -------------------------------------------------------------------------
+  // save_dir precedence
+  // -------------------------------------------------------------------------
+
+  it('save_dir param takes precedence over env var', async () => {
+    globalThis.fetch = makeFetchMock();
+    process.env.COMPANIES_HOUSE_DOWNLOAD_DIR = '/tmp/env-dir';
+    const tool = getTool('download_filing_document')!;
+    await tool.execute(client, {
+      document_id: 'DOC004',
+      return_as: 'file_path',
+      save_dir: '/tmp/param-dir',
+    });
+    expect(vi.mocked(mkdir)).toHaveBeenCalledWith('/tmp/param-dir', { recursive: true });
+    const [filePath] = vi.mocked(writeFile).mock.calls[0] as [string, Buffer];
+    expect(filePath).toMatch(/^\/tmp\/param-dir\//);
+  });
+
+  it('COMPANIES_HOUSE_DOWNLOAD_DIR env var used when no save_dir param', async () => {
+    globalThis.fetch = makeFetchMock();
+    process.env.COMPANIES_HOUSE_DOWNLOAD_DIR = '/tmp/env-dir';
+    const tool = getTool('download_filing_document')!;
+    await tool.execute(client, { document_id: 'DOC005', return_as: 'file_path' });
+    expect(vi.mocked(mkdir)).toHaveBeenCalledWith('/tmp/env-dir', { recursive: true });
+    const [filePath] = vi.mocked(writeFile).mock.calls[0] as [string, Buffer];
+    expect(filePath).toMatch(/^\/tmp\/env-dir\//);
+  });
+
+  it('falls back to OS tmpdir when no save_dir or env var', async () => {
+    globalThis.fetch = makeFetchMock();
+    const tool = getTool('download_filing_document')!;
+    await tool.execute(client, { document_id: 'DOC006', return_as: 'file_path' });
+    const [filePath] = vi.mocked(writeFile).mock.calls[0] as [string, Buffer];
+    expect(filePath).toMatch(new RegExp(`^${tmpdir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+  });
+
+  // -------------------------------------------------------------------------
+  // Direct 200 response (no redirect)
+  // -------------------------------------------------------------------------
+
+  it('handles direct 200 content response without a second fetch', async () => {
+    globalThis.fetch = makeFetchMock({ contentStatus: 200 });
+    const tool = getTool('download_filing_document')!;
+    const result = await tool.execute(client, { document_id: 'DOC007', return_as: 'base64' });
+    expect(result.isError).toBeFalsy();
+    // Only two fetch calls: metadata + content (no S3 hop)
+    const fetchCalls = vi.mocked(globalThis.fetch).mock.calls as Array<[string, unknown]>;
+    const s3Calls = fetchCalls.filter(([u]) => u === S3_URL);
+    expect(s3Calls).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling
+  // -------------------------------------------------------------------------
+
+  it('returns error result when content fetch returns non-200', async () => {
+    globalThis.fetch = makeFetchMock({ contentStatus: 404 });
+    const tool = getTool('download_filing_document')!;
+    const result = await tool.execute(client, { document_id: 'DOC008', return_as: 'base64' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('Error');
+  });
+
+  it('returns error result when S3 fetch fails', async () => {
+    globalThis.fetch = makeFetchMock({ s3Status: 403 });
+    const tool = getTool('download_filing_document')!;
+    const result = await tool.execute(client, { document_id: 'DOC009', return_as: 'base64' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('Error');
+  });
+
+  it('returns error result when API key is not configured', async () => {
+    vi.mocked(resolveApiKey).mockReturnValue(null);
+    globalThis.fetch = makeFetchMock();
+    const tool = getTool('download_filing_document')!;
+    const result = await tool.execute(client, { document_id: 'DOC010', return_as: 'base64' });
+    expect(result.isError).toBe(true);
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
+  });
+
+  it('returns error result when redirect has no Location header', async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if ((url as string).includes('/content')) {
+        return new Response(null, { status: 302 }); // no Location
+      }
+      return new Response('{}', { status: 200 });
+    }) as typeof globalThis.fetch;
+    const tool = getTool('download_filing_document')!;
+    const result = await tool.execute(client, { document_id: 'DOC011', return_as: 'base64' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('Error');
+  });
+});

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "companies-house-mcp",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "MCP server for the UK Companies House API — connects Claude, Cursor, Zed, and other AI tools to live company data",
   "type": "module",
   "mcpName": "io.github.aicayzer/companies-house",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.aicayzer/companies-house",
   "description": "MCP server and CLI for the UK Companies House API. Search, filings, officers, due diligence.",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "repository": {
     "url": "https://github.com/aicayzer/companies-house-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "companies-house-mcp",
-      "version": "3.0.2",
+      "version": "3.1.0",
       "runtime": "node",
       "transport": { "type": "stdio" },
       "environmentVariables": [


### PR DESCRIPTION
Builds on #18 (contributed by @ibex7777). Incorporates all four commits from that branch plus two additional commits:

## What's included

**From #18 (ibex7777):**
- `download_filing_document` tool — fetches actual filed documents (PDF/XHTML/XML/JSON) via the Document API, with `file_path` and `base64` return modes
- HTTP transport crash fix — stateless mode (fresh `McpServer` + transport per request) to fix "Already connected to a transport" on second request
- Optional bearer-token auth via `MCP_BEARER_TOKEN`
- Optional OAuth `client_credentials` grant via `MCP_OAUTH_CLIENT_ID` / `MCP_OAUTH_CLIENT_SECRET`

**Added in this PR:**
- `packages/cli/src/server/oauth.ts` — OAuth endpoint logic extracted from `main()` so `server/index.ts` stays readable (~185 lines vs ~410)
- `tests/unit/tools/download-filing-document.test.ts` — 15 unit tests covering normaliseDocumentId, file_path/base64 modes, S3 auth-stripping, save_dir precedence, error cases

## Closes
Closes #18

## Verification
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm build` — clean
- `pnpm test:unit` — 74/74 passing (15 new)