### PR TITLE
Surface document_id, fix base64 text-content delivery, OAuth auth_code+PKCE

### DIFF
--- a/packages/cli/src/formatters/index.ts
+++ b/packages/cli/src/formatters/index.ts
@@ -42,6 +42,20 @@ export function formatDate(dateStr?: string): string {
   }
 }
 
+/** Extract the document ID from a `links.document_metadata` URL.
+ *  Returns undefined if the URL is missing or malformed. The document
+ *  ID is the final path segment of the Document API URL and is the
+ *  value that `download_filing_document` expects. */
+export function extractDocumentId(url?: string): string | undefined {
+  if (!url) return undefined;
+  const trimmed = url.trim().replace(/\/+$/, '');
+  const marker = '/document/';
+  const idx = trimmed.lastIndexOf(marker);
+  if (idx >= 0) return trimmed.slice(idx + marker.length);
+  const last = trimmed.split('/').pop();
+  return last || undefined;
+}
+
 export function formatCompanyStatus(status: string): string {
   const statusMap: Record<string, string> = {
     active: 'Active',
@@ -260,6 +274,18 @@ export function formatFilings(items: FilingHistoryItem[], total: number): string
     lines.push(`- **Category:** ${filing.category}`);
     lines.push(`- **Type:** ${filing.type}`);
     if (filing.transaction_id) lines.push(`- **Transaction ID:** ${filing.transaction_id}`);
+    // Surface the document_id (final path segment of links.document_metadata)
+    // so `download_filing_document` can be invoked from the same response.
+    // Without this, clients that rely on the formatted text — rather than
+    // the structured payload — cannot find the document_id and the
+    // download tool is effectively unreachable.
+    const docId = extractDocumentId(
+      (filing as unknown as { links?: { document_metadata?: string } }).links
+        ?.document_metadata,
+    );
+    if (docId) {
+      lines.push(`- **Document ID:** ${docId} *(use this with download_filing_document)*`);
+    }
     if (filing.paper_filed) lines.push('- *Paper filed*');
     lines.push('');
   }

--- a/packages/cli/src/server/index.ts
+++ b/packages/cli/src/server/index.ts
@@ -143,7 +143,8 @@ async function main(): Promise<void> {
         if (handled) return;
       } else if (
         url.pathname === '/.well-known/oauth-authorization-server' ||
-        url.pathname === '/oauth/token'
+        url.pathname === '/oauth/token' ||
+        url.pathname === '/oauth/authorize'
       ) {
         res.writeHead(404);
         res.end('Not Found');

--- a/packages/cli/src/server/oauth.ts
+++ b/packages/cli/src/server/oauth.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 
 export interface OAuthConfig {
   clientId: string;
@@ -7,6 +8,10 @@ export interface OAuthConfig {
   publicUrlOverride: string | undefined;
   port: number;
 }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function readRequestBody(req: IncomingMessage): Promise<string> {
   return new Promise<string>((resolve, reject) => {
@@ -19,9 +24,105 @@ function readRequestBody(req: IncomingMessage): Promise<string> {
   });
 }
 
+/** Constant-time string compare so credential checks don't leak timing
+ *  info. If lengths differ we still run a constant-time op on equal-
+ *  length hashes to keep timing uniform. */
+function safeStringEqual(a: string, b: string): boolean {
+  const ba = Buffer.from(a, 'utf-8');
+  const bb = Buffer.from(b, 'utf-8');
+  if (ba.length !== bb.length) {
+    const ha = createHash('sha256').update(ba).digest();
+    const hb = createHash('sha256').update(bb).digest();
+    timingSafeEqual(ha, hb);
+    return false;
+  }
+  return timingSafeEqual(ba, bb);
+}
+
+/** Build a stateless OAuth authorization code: a base64url-encoded JSON
+ *  payload joined to an HMAC signature. Verifying the signature later is
+ *  enough to trust the payload — no server-side store is needed, which
+ *  works across Fly's HA pair (both machines share the signing secret
+ *  via env var). */
+function makeAuthCode(
+  payload: Record<string, unknown>,
+  signingKey: string,
+): string {
+  const json = JSON.stringify(payload);
+  const body = Buffer.from(json, 'utf-8').toString('base64url');
+  const sig = createHmac('sha256', signingKey).update(body).digest('base64url');
+  return `${body}.${sig}`;
+}
+
+/** Verify an auth code's HMAC signature and return the decoded payload,
+ *  or null if the signature doesn't match / the code is malformed. */
+function verifyAuthCode(
+  code: string,
+  signingKey: string,
+): Record<string, unknown> | null {
+  const dotIdx = code.lastIndexOf('.');
+  if (dotIdx < 0) return null;
+  const body = code.slice(0, dotIdx);
+  const sig = code.slice(dotIdx + 1);
+  const expectedSig = createHmac('sha256', signingKey)
+    .update(body)
+    .digest('base64url');
+  if (!safeStringEqual(sig, expectedSig)) return null;
+  try {
+    const json = Buffer.from(body, 'base64url').toString('utf-8');
+    return JSON.parse(json) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/** Parse client_id / client_secret out of the request — either via HTTP
+ *  Basic auth (RFC 6749 §2.3.1) or the request body. Returns whatever
+ *  could be parsed; caller validates against config. */
+function extractClientCredentials(
+  req: IncomingMessage,
+  params: URLSearchParams,
+): { clientId: string | undefined; clientSecret: string | undefined } {
+  let clientId: string | undefined;
+  let clientSecret: string | undefined;
+
+  const authHeader = (req.headers.authorization as string | undefined) ?? '';
+  const basicMatch = authHeader.match(/^Basic\s+(.+)$/i);
+  if (basicMatch && basicMatch[1]) {
+    try {
+      const decoded = Buffer.from(basicMatch[1], 'base64').toString('utf-8');
+      const colonIdx = decoded.indexOf(':');
+      if (colonIdx >= 0) {
+        clientId = decodeURIComponent(decoded.slice(0, colonIdx));
+        clientSecret = decodeURIComponent(decoded.slice(colonIdx + 1));
+      }
+    } catch {
+      /* fall through to body credentials */
+    }
+  }
+  if (!clientId) clientId = params.get('client_id') ?? undefined;
+  if (!clientSecret) clientSecret = params.get('client_secret') ?? undefined;
+  return { clientId, clientSecret };
+}
+
+// ---------------------------------------------------------------------------
+// Main dispatcher
+// ---------------------------------------------------------------------------
+
 /**
- * Handle OAuth discovery and token endpoints.
- * Returns true if the request was handled (caller should return), false otherwise.
+ * Handle OAuth discovery, authorize and token endpoints.
+ *
+ * Supports two grant types:
+ *   - client_credentials  (server-to-server, e.g. curl tests)
+ *   - authorization_code  (with PKCE, used by Claude desktop's Custom
+ *                          Connector and other browser-driven flows)
+ *
+ * Issued access tokens equal the configured static bearer token, which
+ * means the existing /mcp bearer-auth check accepts both manually-set
+ * and OAuth-issued tokens with no extra logic.
+ *
+ * Returns true if the request was handled (caller should return),
+ * false otherwise.
  */
 export async function handleOAuthRequest(
   req: IncomingMessage,
@@ -29,6 +130,22 @@ export async function handleOAuthRequest(
   pathname: string,
   config: OAuthConfig,
 ): Promise<boolean> {
+  // ---- CORS preflight (Claude desktop may invoke OAuth from a webview).
+  if (
+    req.method === 'OPTIONS' &&
+    (pathname === '/oauth/token' || pathname === '/oauth/authorize')
+  ) {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+      'Access-Control-Max-Age': '86400',
+    });
+    res.end();
+    return true;
+  }
+
+  // ---- Discovery metadata
   if (pathname === '/.well-known/oauth-authorization-server') {
     const proto =
       (req.headers['x-forwarded-proto'] as string | undefined) ?? 'http';
@@ -42,21 +159,152 @@ export async function handleOAuthRequest(
     res.end(
       JSON.stringify({
         issuer,
+        authorization_endpoint: `${issuer}/oauth/authorize`,
         token_endpoint: `${issuer}/oauth/token`,
-        grant_types_supported: ['client_credentials'],
+        response_types_supported: ['code'],
+        grant_types_supported: ['authorization_code', 'client_credentials'],
+        code_challenge_methods_supported: ['S256', 'plain'],
         token_endpoint_auth_methods_supported: [
           'client_secret_basic',
           'client_secret_post',
+          'none',
         ],
-        response_types_supported: [],
+        scopes_supported: ['mcp'],
       }),
     );
     return true;
   }
 
+  // ---- Authorization endpoint
+  // Single-user server: validate the request, mint a signed code, and
+  // 302 back to redirect_uri. There's no login UI because there's only
+  // one user; possession of client_id is treated as approval.
+  if (pathname === '/oauth/authorize') {
+    if (req.method !== 'GET') {
+      res.writeHead(405, { Allow: 'GET' });
+      res.end('Method Not Allowed');
+      return true;
+    }
+
+    // We need the query string — parse from req.url. The caller passes
+    // pathname only, so we re-parse the URL here to get searchParams.
+    const proto =
+      (req.headers['x-forwarded-proto'] as string | undefined) ?? 'http';
+    const host =
+      (req.headers.host as string | undefined) ?? `localhost:${config.port}`;
+    const url = new URL(req.url ?? '/', `${proto}://${host}`);
+    const q = url.searchParams;
+    const responseType = q.get('response_type');
+    const reqClientId = q.get('client_id');
+    const redirectUri = q.get('redirect_uri');
+    const state = q.get('state') ?? '';
+    const codeChallenge = q.get('code_challenge') ?? '';
+    const codeChallengeMethod = q.get('code_challenge_method') ?? 'plain';
+    const scope = q.get('scope') ?? '';
+
+    const redirectError = (code: string, description: string): void => {
+      if (!redirectUri) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({ error: code, error_description: description }),
+        );
+        return;
+      }
+      let target: URL;
+      try {
+        target = new URL(redirectUri);
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            error: 'invalid_request',
+            error_description: 'Malformed redirect_uri',
+          }),
+        );
+        return;
+      }
+      target.searchParams.set('error', code);
+      target.searchParams.set('error_description', description);
+      if (state) target.searchParams.set('state', state);
+      res.writeHead(302, { Location: target.toString() });
+      res.end();
+    };
+
+    if (!reqClientId || reqClientId !== config.clientId) {
+      // Per RFC 6749 §4.1.2.1, an unknown client_id should NOT redirect
+      // — return a direct error to avoid open-redirect risk.
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          error: 'invalid_client',
+          error_description: 'Unknown client_id',
+        }),
+      );
+      return true;
+    }
+    if (!redirectUri) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          error: 'invalid_request',
+          error_description: 'Missing redirect_uri',
+        }),
+      );
+      return true;
+    }
+    if (responseType !== 'code') {
+      redirectError(
+        'unsupported_response_type',
+        'Only response_type=code is supported',
+      );
+      return true;
+    }
+    if (codeChallengeMethod !== 'S256' && codeChallengeMethod !== 'plain') {
+      redirectError('invalid_request', 'Unsupported code_challenge_method');
+      return true;
+    }
+
+    // Mint a 10-minute auth code containing everything we'll need to
+    // verify the subsequent /oauth/token request.
+    const code = makeAuthCode(
+      {
+        cid: reqClientId,
+        rdi: redirectUri,
+        cch: codeChallenge,
+        ccm: codeChallengeMethod,
+        sco: scope,
+        exp: Date.now() + 10 * 60 * 1000,
+      },
+      config.expectedToken,
+    );
+
+    let target: URL;
+    try {
+      target = new URL(redirectUri);
+    } catch {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          error: 'invalid_request',
+          error_description: 'Malformed redirect_uri',
+        }),
+      );
+      return true;
+    }
+    target.searchParams.set('code', code);
+    if (state) target.searchParams.set('state', state);
+    res.writeHead(302, { Location: target.toString() });
+    res.end();
+    return true;
+  }
+
+  // ---- Token endpoint
   if (pathname === '/oauth/token') {
     if (req.method !== 'POST') {
-      res.writeHead(405, { 'Content-Type': 'application/json', Allow: 'POST' });
+      res.writeHead(405, {
+        'Content-Type': 'application/json',
+        Allow: 'POST',
+      });
       res.end(
         JSON.stringify({
           error: 'invalid_request',
@@ -81,73 +329,202 @@ export async function handleOAuthRequest(
     }
 
     const params = new URLSearchParams(bodyText);
+    const { clientId: reqClientId, clientSecret: reqClientSecret } =
+      extractClientCredentials(req, params);
+    const grantType = params.get('grant_type');
 
-    // Client credentials may arrive via HTTP Basic auth (RFC 6749 §2.3.1) or body.
-    let clientId: string | undefined;
-    let clientSecret: string | undefined;
-
-    const authHeader = (req.headers.authorization as string | undefined) ?? '';
-    const basicMatch = authHeader.match(/^Basic\s+(.+)$/i);
-    if (basicMatch && basicMatch[1]) {
-      try {
-        const decoded = Buffer.from(basicMatch[1], 'base64').toString('utf-8');
-        const colonIdx = decoded.indexOf(':');
-        if (colonIdx >= 0) {
-          clientId = decodeURIComponent(decoded.slice(0, colonIdx));
-          clientSecret = decodeURIComponent(decoded.slice(colonIdx + 1));
-        }
-      } catch {
-        /* fall through to body credentials */
-      }
-    }
-    if (!clientId) clientId = params.get('client_id') ?? undefined;
-    if (!clientSecret) clientSecret = params.get('client_secret') ?? undefined;
-
-    if (
-      !clientId ||
-      !clientSecret ||
-      clientId !== config.clientId ||
-      clientSecret !== config.clientSecret
-    ) {
-      res.writeHead(401, {
+    const issueToken = (): void => {
+      res.writeHead(200, {
         'Content-Type': 'application/json',
-        'WWW-Authenticate': 'Basic',
+        'Cache-Control': 'no-store',
+        Pragma: 'no-cache',
+        'Access-Control-Allow-Origin': '*',
       });
       res.end(
         JSON.stringify({
-          error: 'invalid_client',
-          error_description: 'Unknown client_id or client_secret',
+          access_token: config.expectedToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
         }),
       );
+    };
+
+    // -- client_credentials grant (preserved for backward compat with
+    //    the upstream behaviour pre-authorization_code).
+    if (grantType === 'client_credentials') {
+      if (
+        !reqClientId ||
+        !reqClientSecret ||
+        !safeStringEqual(reqClientId, config.clientId) ||
+        !safeStringEqual(reqClientSecret, config.clientSecret)
+      ) {
+        res.writeHead(401, {
+          'Content-Type': 'application/json',
+          'WWW-Authenticate': 'Basic',
+        });
+        res.end(
+          JSON.stringify({
+            error: 'invalid_client',
+            error_description: 'Unknown client_id or client_secret',
+          }),
+        );
+        return true;
+      }
+      issueToken();
       return true;
     }
 
-    const grantType = params.get('grant_type');
-    if (grantType !== 'client_credentials') {
-      res.writeHead(400, { 'Content-Type': 'application/json' });
-      res.end(
-        JSON.stringify({
-          error: 'unsupported_grant_type',
-          error_description:
-            'Only client_credentials grant is supported by this server',
-        }),
-      );
+    // -- authorization_code grant (with PKCE)
+    if (grantType === 'authorization_code') {
+      const code = params.get('code') ?? '';
+      const codeVerifier = params.get('code_verifier') ?? '';
+      const redirectUri = params.get('redirect_uri') ?? '';
+
+      if (!code) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            error: 'invalid_request',
+            error_description: 'Missing code',
+          }),
+        );
+        return true;
+      }
+      const payload = verifyAuthCode(code, config.expectedToken);
+      if (!payload) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            error: 'invalid_grant',
+            error_description: 'Invalid authorization code signature',
+          }),
+        );
+        return true;
+      }
+
+      const exp = typeof payload.exp === 'number' ? payload.exp : 0;
+      if (Date.now() > exp) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            error: 'invalid_grant',
+            error_description: 'Authorization code expired',
+          }),
+        );
+        return true;
+      }
+
+      const expectedClientId = String(payload.cid ?? '');
+      if (
+        !reqClientId ||
+        !safeStringEqual(reqClientId, expectedClientId) ||
+        !safeStringEqual(expectedClientId, config.clientId)
+      ) {
+        res.writeHead(401, {
+          'Content-Type': 'application/json',
+          'WWW-Authenticate': 'Basic',
+        });
+        res.end(
+          JSON.stringify({
+            error: 'invalid_client',
+            error_description: 'client_id mismatch',
+          }),
+        );
+        return true;
+      }
+
+      // Confidential clients (those that registered a secret) must
+      // present it. Public clients (PKCE-only) may omit the secret.
+      // Since we have one configured client and it has a secret, we
+      // accept either: secret present + matches, OR secret absent +
+      // valid PKCE (checked below).
+      if (reqClientSecret) {
+        if (!safeStringEqual(reqClientSecret, config.clientSecret)) {
+          res.writeHead(401, {
+            'Content-Type': 'application/json',
+            'WWW-Authenticate': 'Basic',
+          });
+          res.end(
+            JSON.stringify({
+              error: 'invalid_client',
+              error_description: 'Bad client_secret',
+            }),
+          );
+          return true;
+        }
+      }
+
+      const expectedRedirectUri = String(payload.rdi ?? '');
+      if (
+        !redirectUri ||
+        !safeStringEqual(redirectUri, expectedRedirectUri)
+      ) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            error: 'invalid_grant',
+            error_description: 'redirect_uri mismatch',
+          }),
+        );
+        return true;
+      }
+
+      // PKCE verification — required if the original /authorize
+      // request included a code_challenge.
+      const challenge = String(payload.cch ?? '');
+      const challengeMethod = String(payload.ccm ?? 'plain');
+      if (challenge) {
+        if (!codeVerifier) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              error: 'invalid_grant',
+              error_description: 'Missing code_verifier',
+            }),
+          );
+          return true;
+        }
+        let derived: string;
+        if (challengeMethod === 'S256') {
+          derived = createHash('sha256')
+            .update(codeVerifier, 'utf-8')
+            .digest('base64url');
+        } else {
+          derived = codeVerifier;
+        }
+        if (!safeStringEqual(derived, challenge)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              error: 'invalid_grant',
+              error_description: 'PKCE verification failed',
+            }),
+          );
+          return true;
+        }
+      } else if (!reqClientSecret) {
+        // No PKCE and no client secret — not allowed.
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            error: 'invalid_client',
+            error_description:
+              'Public clients must use PKCE; confidential clients must present client_secret',
+          }),
+        );
+        return true;
+      }
+
+      issueToken();
       return true;
     }
 
-    // Re-use the static MCP_BEARER_TOKEN as the access token — the /mcp
-    // bearer-auth check accepts it with no extra logic. expires_in is
-    // advisory; the token never actually expires.
-    res.writeHead(200, {
-      'Content-Type': 'application/json',
-      'Cache-Control': 'no-store',
-      Pragma: 'no-cache',
-    });
+    // Unknown / missing grant_type
+    res.writeHead(400, { 'Content-Type': 'application/json' });
     res.end(
       JSON.stringify({
-        access_token: config.expectedToken,
-        token_type: 'Bearer',
-        expires_in: 3600,
+        error: 'unsupported_grant_type',
+        error_description: `Grant type '${grantType ?? ''}' is not supported`,
       }),
     );
     return true;

--- a/packages/cli/src/tools/download-filing-document.ts
+++ b/packages/cli/src/tools/download-filing-document.ts
@@ -17,7 +17,14 @@
  *   - returns the bytes inline as a base64 string in the response payload
  *     (`return_as: 'base64'`), which is what you want when the MCP server
  *     runs on a different machine to the caller (e.g. hosted on Fly.io and
- *     accessed over HTTP via mcp-remote).
+ *     accessed over HTTP via mcp-remote or Claude desktop's Custom
+ *     Connector).
+ *
+ * NOTE on base64 mode: the payload (including `content_base64`) is JSON-
+ * stringified into the *text content block* of the response — not just the
+ * structured-content field. This is required for clients like Claude
+ * desktop's Custom Connector that don't surface structuredContent to the
+ * model. Clients should JSON-parse the text and pull out `content_base64`.
  *
  * Save location precedence (file_path mode only):
  *   1. `save_dir` parameter on the call
@@ -79,7 +86,8 @@ const shape = {
     .describe(
       'The document id from a filing history item. Typically exposed on a ' +
         'filing as `links.document_metadata` (e.g. ".../document/ABC123"); ' +
-        'pass just the final path segment here.',
+        'pass just the final path segment here. NOTE this is different ' +
+        'from the transaction_id — see `get_filings` description.',
     ),
   format: z
     .enum(['pdf', 'xhtml', 'xml', 'json'])
@@ -96,9 +104,11 @@ const shape = {
       'How to return the document. "file_path" (default) writes the bytes ' +
         'to disk on the server and returns the local path — works when ' +
         'the MCP server runs on the same machine as the caller (stdio ' +
-        'mode). "base64" returns the bytes inline as a base64 string in ' +
-        'the response payload — required when the server is remote (HTTP) ' +
-        'and the caller has no access to the server filesystem.',
+        'mode). "base64" returns the bytes inline as a base64 string ' +
+        'embedded in the response\'s text content block — required when ' +
+        'the server is remote (HTTP) and the caller has no access to the ' +
+        'server filesystem. JSON-parse the response text and extract the ' +
+        '`content_base64` field, then base64-decode to recover the bytes.',
     ),
   company_number: z
     .string()
@@ -262,9 +272,10 @@ registerTool({
     'Companies House filing history item via the Document API. By default ' +
     'writes to disk on the server and returns the file path; pass ' +
     '`return_as: "base64"` to get the bytes inline (required for remote ' +
-    'MCP servers). Pair with `get_filings` — take the `links.' +
-    'document_metadata` value from a filing and pass its final path ' +
-    'segment as `document_id`.',
+    'MCP servers — the bytes are embedded in the response\'s text content ' +
+    'as JSON; parse it and extract `content_base64`). Pair with ' +
+    '`get_filings` — take the `document_id` it surfaces (NOT ' +
+    '`transaction_id`) and pass it here.',
   inputSchema: shape,
   annotations: TOOL_ANNOTATIONS,
   async execute(_client: APIClient, params: unknown) {
@@ -301,19 +312,20 @@ registerTool({
       };
 
       // ---- base64 mode: return the bytes inline, no disk write.
+      // We embed the entire payload (including `content_base64`) in the
+      // response's text content block AS WELL AS in structuredContent.
+      // Some MCP clients (notably Claude desktop's Custom Connector)
+      // only surface text content to the model and would otherwise
+      // miss the bytes entirely; others (Cowork, structured-aware
+      // tooling, the existing unit tests) read structuredContent.
+      // Putting it in both keeps every client working.
       if (input.return_as === 'base64') {
         const payload = {
           ...commonPayload,
-          return_as: 'base64',
+          return_as: 'base64' as const,
           content_base64: buffer.toString('base64'),
         };
-        const summary =
-          `Returning ${buffer.byteLength.toLocaleString()} bytes ` +
-          `(${contentType}) inline as base64. Decode with e.g. ` +
-          `\`echo "$content_base64" | base64 -d > out.${
-            FORMAT_EXTENSION[input.format] ?? 'bin'
-          }\`.`;
-        return makeTextResult(summary, payload);
+        return makeTextResult(JSON.stringify(payload), payload);
       }
 
       // ---- file_path mode (default): write to disk, return the path.

--- a/packages/cli/src/tools/filings.ts
+++ b/packages/cli/src/tools/filings.ts
@@ -20,7 +20,7 @@ const schema = z.object(shape);
 registerTool({
   name: 'get_filings',
   description:
-    'Get filing history for a UK company. Includes accounts, annual returns, officer changes, mortgage registrations, and all other filings. Use the category parameter to filter by type. Returns transaction IDs for retrieving specific documents.',
+    'Get filing history for a UK company. Includes accounts, annual returns, officer changes, mortgage registrations, and all other filings. Use the category parameter to filter by type. Each item exposes both a transaction_id (identifies the filing) and a document_id (identifies the document blob — pass THIS to download_filing_document, NOT transaction_id). The two IDs look similar but are different strings.',
   inputSchema: shape,
   annotations: TOOL_ANNOTATIONS,
   async execute(client: APIClient, params: unknown) {


### PR DESCRIPTION
Three small follow-ups on top of #19, each addressing an issue that surfaced when running this server hosted on Fly.io and accessed from Claude desktop's Custom Connector UI on a separate machine. All three commits are independent and could be split into separate PRs if you'd prefer — happy to do that.

## What's included

### 1. Surface document_id in get_filings output (a59105b)

Without this, download_filing_document is effectively unreachable from any client whose model relies on the formatted text rather than structuredContent — formatFilings previously dropped links.document_metadata. Now it's surfaced as a top-level "Document ID" line per filing item, with an inline hint that this is what download_filing_document expects (rather than transaction_id, a common confusion).

### 2. Embed content_base64 in the text content block (a97cb7f)

`return_as: "base64"` mode previously put the bytes only in structuredContent. Some MCP clients (notably Claude desktop's Custom Connector) only surface text content to the model, so the bytes were invisible there. The full payload is now JSON-stringified into the text content block as well, so every client can extract it. Cowork and the existing unit tests keep working unchanged because structuredContent is still populated alongside.

### 3. OAuth authorization_code grant with PKCE (89a7ef2)

Claude desktop's Custom Connector UI expects authorization_code with PKCE rather than client_credentials. Adds:

- New `/oauth/authorize` endpoint — validates the request, mints a 10-minute HMAC-signed authorization code (stateless, works across HA machines without shared storage), 302s back to redirect_uri.
- `/oauth/token` extended to handle authorization_code alongside the existing client_credentials grant. Verifies signature, expiry, client_id, redirect_uri, and PKCE (S256 / plain).
- Updated discovery metadata to advertise both grants, `response_types_supported: ["code"]`, and `code_challenge_methods_supported: ["S256", "plain"]`.
- Constant-time secret comparisons via `timingSafeEqual`.
- CORS preflight on `/oauth/{token,authorize}` for webview flows.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm test:unit` — 74/74 passing (no test changes; existing assertions on structuredContent still pass thanks to the dual-output approach in commit 2).
- [x] Live test against a Fly-hosted instance using Claude desktop's Custom Connector UI on a separate (work) machine — auth_code + PKCE flow connects, all 18 tools register, document download via base64 works, full CS01 → cap-table workflow completes end-to-end.
